### PR TITLE
Update the save_visualization function.

### DIFF
--- a/isegm/engine/trainer.py
+++ b/isegm/engine/trainer.py
@@ -277,6 +277,7 @@ class ISTrainer(object):
         num_masks = points.shape[0]
         gt_masks = np.squeeze(gt_instance_masks[:num_masks], axis=1)
         predicted_masks = np.squeeze(predicted_instance_masks[:num_masks], axis=1)
+        image = image[:, :, ::-1]
 
         viz_image = []
         for gt_mask, point, predicted_mask in zip(gt_masks, points, predicted_masks):
@@ -291,7 +292,7 @@ class ISTrainer(object):
         viz_image = np.vstack(viz_image)
 
         result = viz_image.astype(np.uint8)
-        _save_image('instance_segmentation', result[:, :, ::-1])
+        _save_image('instance_segmentation', result)
 
     def _load_weights(self):
         if self.cfg.weights is not None:


### PR DESCRIPTION
Thank you for providing such beautiful code. Make some suggestions based on personal use.
It can be seen from the code that the predicted_mask is saved in the form of a heat map. Your team adopted cv2.COLORMAP_HOT.
![maphot](https://user-images.githubusercontent.com/24953417/88143507-e4a58680-cc29-11ea-8af7-3a04e943fd04.png)
But after np.hstack, result[:, :, ::-1] is added. This should be used in the processing of the input image, not in the predicted_mask. The result before the change is like this.
![125200_instance_segmentation](https://user-images.githubusercontent.com/24953417/88143636-25050480-cc2a-11ea-86c3-aa2fbda003b2.jpg)
I made some adjustments.The results obtained are feasible.
![1](https://user-images.githubusercontent.com/24953417/88143849-7f9e6080-cc2a-11ea-99b0-343db36e9c7e.png)